### PR TITLE
Added a command line option "--a" to select an ondemand application t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Download the [latest release](https://github.com/ghuntley/atlassian-cloud-backup
 	  -i, --instance       Required. Atlassian Cloud instance url.
 	  -u, --username       Required. Atlassian Cloud username with administrative privledges.
 	  -p, --password       Required. Password for administrative account.
+	  -a, --application    Applications to backup j for Jira, c for Confluence, jc for both.
 	  --help               Display this help screen.
 
 # Usage

--- a/src/AtlassianCloudBackup/CommandLineOptions.cs
+++ b/src/AtlassianCloudBackup/CommandLineOptions.cs
@@ -33,10 +33,15 @@ namespace AtlassianCloudBackup
         ]
         public string Username { get; set; }
 
-
+        
         [Option('p', "password", Required = true, HelpText = "Password for administrative account.")]
         public string Password { get; set; }
 
+        
+        [Option('a', "application", Required = false, DefaultValue="jc", HelpText = "Applications to backup j for Jira, c for Confluence, jc for both.")]
+        public string Applications { get; set; }
+
+        
 
         [HelpOption]
         public string GetUsage()

--- a/src/AtlassianCloudBackup/Program.cs
+++ b/src/AtlassianCloudBackup/Program.cs
@@ -66,13 +66,13 @@ namespace AtlassianCloudBackup
 
                     await backupClient.AuthenticateAsync();
 
-                    await backupClient.RequestJiraBackupAsync();
-                    await backupClient.RequestConfluenceBackupAsync();
+                    if(options.Applications.Contains("j")) await backupClient.RequestJiraBackupAsync();
+                    if(options.Applications.Contains("c")) await backupClient.RequestConfluenceBackupAsync();
 
                     logger.Information("Sleeping for {seconds} seconds before starting download(s).", options.Sleep);
                     Thread.Sleep(options.Sleep*1000);
-                    await backupClient.DownloadJiraBackupAsync(new Uri(options.DestinationPath), DateTime.Now);
-                    await backupClient.DownloadConfluenceBackupAsync(new Uri(options.DestinationPath), DateTime.Now);
+                    if(options.Applications.Contains("j"))  await backupClient.DownloadJiraBackupAsync(new Uri(options.DestinationPath), DateTime.Now);
+                    if(options.Applications.Contains("c")) await backupClient.DownloadConfluenceBackupAsync(new Uri(options.DestinationPath), DateTime.Now);
 
                     logger.Information("Finished backup.");
                     Environment.Exit((int) ExitCode.Success);


### PR DESCRIPTION
Added a command line option "--a" to select an ondemand application to back up if you only use jira or confluence but not the other. j = jira, c = confluence, jc = both
